### PR TITLE
Use schema.yml table defined id if wordpress doesn't return one.

### DIFF
--- a/plugins/versionpress/src/Database/WpdbMirrorBridge.php
+++ b/plugins/versionpress/src/Database/WpdbMirrorBridge.php
@@ -357,8 +357,13 @@ class WpdbMirrorBridge
     private function processInsertQuery($parsedQueryData)
     {
 
+        if ($this->database->insert_id == 0) {
+            $idColumnNames = $parsedQueryData->idColumnsNames[0];
+            $id = $parsedQueryData->data[0][$idColumnNames];
+        } else {
+            $id = $this->database->insert_id;
+        }
 
-        $id = $this->database->insert_id;
         $entitiesCount = count($parsedQueryData->data);
 
         for ($i = 0; $i < $entitiesCount; $i++) {


### PR DESCRIPTION
Resolves #1175

When table does not use auto-increment for an ID, wordpress returns an ID of 0 so we use the field defined as the ID in the schema.yml file.